### PR TITLE
Add random wait at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ instance_address_property: public_ip_address
 hosted_zone:               example.com.
 record_set:                '*.example.com'
 health_check_tag:          example_health_check
+startup_delay_random:      60
 
 health_check_config:
     :port:              80
@@ -70,6 +71,7 @@ health_check_config:
 
 This configuration will cause the script to work in the following way:
 
+  * Wait between 0 and 60 seconds (optional; avoids "thundering herd" effects)
   * Enumerate all hosts in the `example_asg` autoscaling group.
   * Obtain their public IP address
   * Create health checks following the health_check_config settings for each IP (if these don't exist), tagging them with `example_health_check`.

--- a/sf-r53-update
+++ b/sf-r53-update
@@ -75,6 +75,14 @@ end
 
 log.debug("Config: #{config}")
 
+# If configured, delay startup
+# Skip this for interactive use
+if config['startup_delay_random'] and not (STDOUT.isatty or STDERR.isatty or options[:noop])
+    startup_delay = rand(config['startup_delay_random'])
+    log.info("Waiting #{startup_delay}s (maximum #{config['startup_delay_random']})")
+    sleep(startup_delay)
+end
+
 # If we haven't set a region in the environment, try and find one from
 # the link-local endpoint.
 
@@ -92,6 +100,8 @@ unless ENV.key?('AWS_REGION')
     end
 
 end
+
+
 
 # Create clients for the API 
 


### PR DESCRIPTION
Avoid a “thundering herd” effect if multiple instances / regions / whatever are running the same tool at once.